### PR TITLE
Add robust credential persistence

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - FROST_USER=sta-manager
       # - FROST_PASSWORD=ChangeMe
       - CONTAINER_ENVIRONMENT=true
+    volumes:
+      - python-app_credentials:/app/credentials
     command: ["uv", "run", "/app/src/sensorthings_utils/main.py"]
 
   web:
@@ -59,3 +61,4 @@ services:
 
 volumes:
   postgis_volume:
+  python-app_credentials:

--- a/src/sensorthings_utils/config.py
+++ b/src/sensorthings_utils/config.py
@@ -15,8 +15,7 @@ ROOT_DIRECTORY = Path(__file__).parent.parent.parent
 
 def _make_credentials_dir() -> Path:
     """
-    Create a credentials directory in the project root if is does not exist.
-
+    Create a credentials directory in the project root if it does not exist.
     Credentials for all supported sensor types are *initially* stored in a .env file,
     once they are parsed (by internal functions credentials), credenentials kept in the
     .credentials directory.

--- a/src/sensorthings_utils/config.py
+++ b/src/sensorthings_utils/config.py
@@ -17,7 +17,7 @@ def _make_credentials_dir() -> Path:
     """
     Create a credentials directory in the project root if it does not exist.
     Credentials for all supported sensor types are *initially* stored in a .env file,
-    once they are parsed (by internal functions credentials), credenentials kept in the
+    once they are parsed (by internal functions credentials), credentials kept in the
     .credentials directory.
     """
     credentials_directory = ROOT_DIRECTORY / ".credentials"

--- a/src/sensorthings_utils/config.py
+++ b/src/sensorthings_utils/config.py
@@ -11,6 +11,23 @@ from lnetatmo import ClientAuth
 
 # directory setup
 ROOT_DIRECTORY = Path(__file__).parent.parent.parent
+
+
+def _make_credentials_dir() -> Path:
+    """
+    Create a credentials directory in the project root if is does not exist.
+
+    Credentials for all supported sensor types are *initially* stored in a .env file,
+    once they are parsed (by internal functions credentials), credenentials kept in the
+    .credentials directory.
+    """
+    credentials_directory = ROOT_DIRECTORY / ".credentials"
+    if not credentials_directory.exists():
+        os.mkdir(credentials_directory)
+    return credentials_directory
+
+
+CREDENTIALS_DIRECTORY = _make_credentials_dir()
 CONFIG_PATHS = ROOT_DIRECTORY / "sensor_configs"
 ENV_FILE = ROOT_DIRECTORY / ".env"
 

--- a/src/sensorthings_utils/netatmo.py
+++ b/src/sensorthings_utils/netatmo.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 # internal
 from .sensor_things.core import Observation
-from .config import ROOT_DIRECTORY, FROST_ENDPOINT, FROST_CREDENTIALS
+from .config import CREDENTIALS_DIRECTORY, FROST_ENDPOINT, FROST_CREDENTIALS
 
 # type checking only
 if TYPE_CHECKING:
@@ -28,11 +28,14 @@ if TYPE_CHECKING:
 # environment setup
 dotenv.load_dotenv(ENV_FILE)
 CONTAINER_ENVIRONMENT = True if os.getenv("CONTAINER_ENVIRONMENT") else False
-
-NETATMO_CREDENTIALS_FILE = Path(ROOT_DIRECTORY / ".netatmo.credentials")
-if not NETATMO_CREDENTIALS_FILE.exists():
-    # Get credentials from the .env, but create a .netatmo.credentials file; the
-    # credentials then become redundant.
+NETATMO_CREDENTIALS_FILE = Path(CREDENTIALS_DIRECTORY / ".netatmo.credentials")
+# create the .netatmo.credentials (from .env) if file doesn't exist, or, if
+# the .env is newer than the .netatmo credentials.
+if not NETATMO_CREDENTIALS_FILE.exists() or os.path.getmtime(
+    ENV_FILE
+) > os.path.getmtime(NETATMO_CREDENTIALS_FILE):
+    if not ENV_FILE.exists():
+        raise FileNotFoundError(".netatmo.credentials nor .env file found.")
     NETATMO_CLIENT_ID = os.getenv("NETATMO_CLIENT_ID")
     NETATMO_CLIENT_SECRET = os.getenv("NETATMO_CLIENT_SECRET")
     NETATMO_REFRESH_TOKEN = os.getenv("NETATMO_REFRESH_TOKEN")


### PR DESCRIPTION
Credentials were being lost in containerized deployments. The template `docker.compose` file now includes a volume mount where credentials will be stored across sessions. Credentials now have a clear home directory.