### PR TITLE
stop baking of .env into container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 docs
 scripts
 .netatmo.credentials
+.env

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -6,19 +6,21 @@ services:
     depends_on:
       - web
       - database
+    env_file:
+      - ../.env
     environment:
       - FROST_ENDPOINT=http://web:8080/FROST-Server/v1.1
-      - FROST_USER=sta-manager
-      # - FROST_PASSWORD=ChangeMe
       - CONTAINER_ENVIRONMENT=true
     volumes:
-      - python-app_credentials:/app/credentials
+      - python-app_credentials:/app/.credentials
     command: ["uv", "run", "/app/src/sensorthings_utils/main.py"]
 
   web:
     image: fraunhoferiosb/frost-server:2.5.3
     volumes:
       - ../web:/usr/local/tomcat/webapps/st-utils
+    env_file:
+      - ../.env
     environment:
       - serviceRootUrl=http://localhost:8080/FROST-Server
       - plugins_multiDatastream.enable=false
@@ -27,13 +29,11 @@ services:
       - persistence_db_driver=org.postgresql.Driver
       - persistence_db_url=jdbc:postgresql://database:5432/sensorthings
       - persistence_db_username=sta-manager
-      # - persistence_db_password=ChangeMe
       - persistence_autoUpdateDatabase=true
       - auth_provider=de.fraunhofer.iosb.ilt.frostserver.auth.basic.BasicAuthProvider
       - auth_db_driver=org.postgresql.Driver
       - auth_db_url=jdbc:postgresql://database:5432/sensorthings
       - auth_db_username=sta-manager
-      # - auth_db_password=ChangeMe
       - auth_autoUpdateDatabase=true
       - auth.allowAnonymousRead=true
     ports:
@@ -45,10 +45,10 @@ services:
 
   database:
     image: postgis/postgis:16-3.4-alpine
+    env_file:
+      - ../.env
     environment:
       - POSTGRES_DB=sensorthings
-      - POSTGRES_USER=sta-manager
-      # - POSTGRES_PASSWORD=ChangeMe
     volumes:
       - postgis_volume:/var/lib/postgresql/data
       - ./init-db.sh:/usr/local/bin/st-utils-init-db.sh


### PR DESCRIPTION
Previous approach saw the .env being baked into the docker image. Replaced by mounting the environment file; as well as some improvements to handling the checks of absence / presence of the .netatmo.credentials.