### PR TITLE
Add Restart Policy to Dockerfile

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - python-app_credentials:/app/.credentials
     command: ["uv", "run", "/app/src/sensorthings_utils/main.py"]
+    restart: unless-stopped
 
   web:
     image: fraunhoferiosb/frost-server:2.5.3


### PR DESCRIPTION
Even though we (try) to handle any connection errors gracefully, we still (sometimes) have the app crashing. As an alternative to controlling this using `systemd` (also valid), introduce a restart mechanism in docker-compose.