### PR TITLE
add sys exit when thread is dead

### DIFF
--- a/src/sensorthings_utils/connections.py
+++ b/src/sensorthings_utils/connections.py
@@ -284,7 +284,7 @@ class CredentialedMQTTSensorConnection(ABC):
         mqtt_port: int,
         credentials_dir: Path = Path(f"{ROOT_DIR}/.credentials"),
         env_file: Path = Path(f"{ROOT_DIR}/.env"),
-        max_retries: int = 10,
+        max_retries: int = 1,
     ):
         self.application_name = application_name
         self.mqtt_host = mqtt_host
@@ -363,7 +363,9 @@ class CredentialedMQTTSensorConnection(ABC):
                 restart_attempts += 1
                 time.sleep(300)
                 logger.warning(
-                    f"Thread {self.application_name} encountered an exception {e}. Sleeping and trying again."
+                    f"Thread {self.application_name} encountered an exception: "+
+                    f"{e}. Sleeping {restart_attempts} of {self.max_retries} " +
+                    "and trying again."
                 )
                 if restart_attempts == self.max_retries:
                     self.stop()

--- a/src/sensorthings_utils/monitor.py
+++ b/src/sensorthings_utils/monitor.py
@@ -6,7 +6,7 @@ import time
 import logging
 import threading
 from collections import defaultdict
-from typing import Mapping
+import sys
 
 logger = logging.getLogger("network_monitor")
 
@@ -64,7 +64,7 @@ class NetworkMonitor:
             thread_line = (
                 f"All original threads alive: {self.starting_application_threads}."
                 if not dead_threads
-                else f"Some threads have died: {dead_threads}."
+                else f"Some threads have died: {dead_threads}. Killing app."
             )
             logger.info(
                 f"Periodic Health Report {"-"*(len(thread_line)-len("Period Health Report"))}"
@@ -73,6 +73,7 @@ class NetworkMonitor:
                 logger.info(thread_line)
             else:
                 logger.warning(thread_line)
+                sys.exit(1)
             # Report succesful pushes:
             logger.info(f"Uptime: {datetime.now()-self.start_time}")
             if self.sensor_config_fail > 0:


### PR DESCRIPTION
Adds a hard `sys.exit()` to kill the entire app when a thread dies. Future TODO could include a thread watcher; but this is unnecessary for now.