### PR TITLE
Patch Restart Policy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "st-utils"
-version = "0.4.0"
+version = "0.4.2"
 description = "Management and representation layer for Fraunhofer FROST Server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/sensorthings_utils/main.py
+++ b/src/sensorthings_utils/main.py
@@ -133,6 +133,8 @@ def push_available(
 
     for connection in sensor_connections:
         connection.start_pull_transform_push_thread(sensor_registry)
+        # network monitor will be responsible for restarting dead threads:
+        netmon.connections.add(connection)
 
     event_logger.info(
         f"Started {threading.active_count()-1} application threads: "
@@ -143,7 +145,7 @@ def push_available(
         while True:
             # TODO: network_monitor should write to a metrics file for eventual
             # integration with monitoring tools.
-            netmon.report(interval=30)
+            netmon.report(interval=5)
     except KeyboardInterrupt:
         for conn in sensor_connections:
             if conn._thread and conn._thread.is_alive():


### PR DESCRIPTION
## Previous

Threads that ran their course and died due to main repeated failures where causing `sys.exit()` to be called from the network monitor object. 

## This PR

Introducing a new connection restart function which is called by a network monitor whenever there are dead threads.