### PR TITLE
chore: refactor Dockerfile to multi-stage build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dockerfile multi-stage build** - Refactored Dockerfile to use multi-stage build
+  pattern with `ghcr.io/astral-sh/uv:python3.13-bookworm` as builder stage and
+  `python:3.13-slim` as runtime stage. This resolves GitHub Container Registry
+  authentication issues, reduces final image size by excluding build tools, and
+  follows Docker best practices for production deployments.
+
 ### Fixed
 
 - **CLI indentation error** - Fixed `IndentationError` in `src/rime/cli/commands.py`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
+# Build stage with uv and build dependencies
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm AS builder
+
+WORKDIR /app
+COPY . /app/
+RUN uv sync --frozen
+
+# Runtime stage - slim final image
 FROM python:3.13-slim
 
 WORKDIR /app
+COPY --from=builder /app /app
 
-COPY . /app/
-
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-ENV PATH="/root/.local/bin:${PATH}"
-RUN uv sync --frozen
+ENV PATH="/app/.venv/bin:${PATH}"
 RUN ls -R /app
 
-CMD ["uv", "run",  "/app/src/rime/main.py"]
+CMD ["python", "/app/src/rime/main.py"]


### PR DESCRIPTION
Replaced the single-stage build with a multi-stage build pattern:

  **Stage 1 - Builder:**
  - Uses ghcr.io/astral-sh/uv:python3.13-bookworm (full image with build tools)
  - Installs all Python dependencies including those requiring compilation (like obspy)
  - This stage has gcc, g++, make and other build tools built-in

  **Stage 2 - Runtime:**
  - Uses python:3.13-slim (minimal Python image)
  - Copies only the built application and dependencies from Stage 1
  - Final image is much smaller and more secure (no build tools)

  **Why this approach:**
  1. Solves authentication issue - Uses full official image instead of copying binaries
  2. Smaller image - Build dependencies stay in Stage 1, not in final image
  3. More secure - No compilers/build tools in production image
  4. Industry standard - Best practice for Docker builds
  5. Better caching - Docker caches stages independently for faster rebuilds