### PR TITLE
Support Multiple Endpoints

### DIFF
--- a/packages/rime-ingest/src/rime_ingest/cli/credentials.py
+++ b/packages/rime-ingest/src/rime_ingest/cli/credentials.py
@@ -2,6 +2,7 @@
 
 # standard
 import json
+import os
 import subprocess
 
 # external
@@ -13,27 +14,44 @@ from getpass import getpass
 
 # internal
 from ..paths import CREDENTIALS_DIR
+from ..config import FROST_ENDPOINT_DEFAULT
 from .system_checks import PRODUCTION_POSTGIS_VOLUME_CANDIDATES, _check_postgres_persistent_volume
 
 console = Console()
 
 
 def setup_frost_credentials():
-    """Setup FROST credentials."""
+    """Setup FROST credentials for one endpoint."""
     console.print(Panel.fit(
         "[bold]FROST Credentials[/bold]",
         border_style="blue"
     ))
-    
-    frost_username = Prompt.ask("FROST username", default="sta-admin")
-    frost_password = getpass("FROST password: ")
-    
-    frost_creds = {
-        "frost_username": frost_username,
-        "frost_password": frost_password
-    }
-    
+
+    endpoint = Prompt.ask(
+        "FROST endpoint (must match FROST_ENDPOINT env var)",
+        default=os.getenv("FROST_ENDPOINT", FROST_ENDPOINT_DEFAULT).split(",")[0].strip(),
+    )
+    write_username = Prompt.ask("FROST write username", default="write")
+    write_password = getpass("FROST write password: ")
+    read_username = Prompt.ask("FROST read username", default=write_username)
+    read_password = getpass("FROST read password: ") or write_password
+
     frost_file = CREDENTIALS_DIR / "frost_credentials.json"
+    frost_creds: dict = {}
+    if frost_file.exists():
+        try:
+            with open(frost_file, "r") as f:
+                frost_creds = json.load(f)
+        except Exception:
+            pass
+
+    frost_creds[endpoint] = {
+        "frost_write_username": write_username,
+        "frost_write_password": write_password,
+        "frost_read_username": read_username,
+        "frost_read_password": read_password,
+    }
+
     if not frost_file.exists():
         frost_file.touch()
 

--- a/packages/rime-ingest/src/rime_ingest/config.py
+++ b/packages/rime-ingest/src/rime_ingest/config.py
@@ -47,9 +47,12 @@ def _sync_frost_version_exports() -> None:
 _sync_frost_version_exports()
 
 
-def get_frost_credentials() -> dict[str, str]:
+def get_frost_credentials() -> dict[str, dict[str, str]]:
     """Read FROST credentials from Docker secret or local credentials file.
-    
+
+    The file maps each ``FROST_ENDPOINT`` value to its read/write credential
+    pairs, e.g. ``{"http://host/FROST-Server/v1.1": {"frost_write_username": ...}}``.
+
     Returns an empty dict if the credentials file does not exist or cannot be
     parsed — callers that need auth will receive None from get_frost_auth_header
     and should omit the Authorization header (anonymous / read-only mode).
@@ -65,15 +68,17 @@ def get_frost_credentials() -> dict[str, str]:
         return {}
 
 
-@lru_cache(maxsize=2)
-def get_frost_auth_header(kind: Literal["read", "write"]) -> str | None:
+@lru_cache(maxsize=None)
+def get_frost_auth_header(kind: Literal["read", "write"], endpoint: str) -> str | None:
     """Return base64-encoded credentials for FROST authorization headers.
-    
-    Returns None when credentials are not configured (anonymous mode).
+
+    ``endpoint`` must match a key in ``frost_credentials.json`` (typically a
+    value from ``FROST_ENDPOINT``). Returns None when credentials are not
+    configured for that endpoint (anonymous mode).
     """
-    credentials = get_frost_credentials()
-    frost_user = credentials.get(f"frost_{kind}_username")
-    frost_password = credentials.get(f"frost_{kind}_password")
+    endpoint_creds = get_frost_credentials().get(endpoint, {})
+    frost_user = endpoint_creds.get(f"frost_{kind}_username")
+    frost_password = endpoint_creds.get(f"frost_{kind}_password")
     if not frost_user or not frost_password:
         return None
     return base64.b64encode(f"{frost_user}:{frost_password}".encode()).decode("utf-8")
@@ -83,7 +88,7 @@ FROST_ROOT_DEFAULT = "http://localhost:8080/FROST-Server"
 FROST_ENDPOINT_DEFAULT = "http://localhost:8080/FROST-Server/v1.1"
 
 
-def get_frost_root_url() -> tuple[str, FrostVersions]:
+def sanitize_frost_root_url(frost_url: str) -> tuple[str, FrostVersions]:
     """Return ``(root_url, version)`` from environment variables or defaults.
 
     Resolution order:
@@ -95,7 +100,6 @@ def get_frost_root_url() -> tuple[str, FrostVersions]:
 
     ``version`` is a ``FrostVersions`` member (also a ``str``, e.g. ``"1.1"``).
     """
-    import re
     version_env = os.getenv("FROST_VERSION")
     version = (
         FrostVersions.safe_parse(version_env)
@@ -109,15 +113,12 @@ def get_frost_root_url() -> tuple[str, FrostVersions]:
         return root, frost_versions.FROST_VERSION
     endpoint = os.getenv("FROST_ENDPOINT")
     if endpoint:
-        m = re.match(r"^(.*?)/(v[\d.]+)$", endpoint)
-        if m:
-            version = FrostVersions.safe_parse(m.group(2))
-            frost_versions.configure_frost_version(version)
-            _sync_frost_version_exports()
-            return m.group(1), frost_versions.FROST_VERSION
-        frost_versions.configure_frost_version(version)
+        from rime_ingest.frost.sanitization import sanitize_frost_endpoint
+
+        _, root, parsed_version = sanitize_frost_endpoint(endpoint, version=version)
+        frost_versions.configure_frost_version(parsed_version)
         _sync_frost_version_exports()
-        return endpoint, frost_versions.FROST_VERSION
+        return root, frost_versions.FROST_VERSION
     frost_versions.configure_frost_version(version)
     _sync_frost_version_exports()
     return FROST_ROOT_DEFAULT, frost_versions.FROST_VERSION

--- a/packages/rime-ingest/src/rime_ingest/frost/post.py
+++ b/packages/rime-ingest/src/rime_ingest/frost/post.py
@@ -3,14 +3,20 @@
 # standard
 import json
 import logging
+import os
 from datetime import datetime, date
 from typing import Any, Mapping, Optional
 # external
 import requests
-from rime_ingest.config import FROST_ROOT_DEFAULT, FROST_VERSION, get_frost_auth_header, get_frost_root_url
+from rime_ingest.config import (
+    FROST_ENDPOINT_DEFAULT,
+    FROST_ROOT_DEFAULT,
+    FROST_VERSION,
+    get_frost_auth_header,
+)
 from rime_ingest.frost.bridges import ENTITY_TO_FROST_ENDPOINT
 from rime_ingest.frost.helpers import check_object_existence
-from rime_ingest.frost.sanitization import rewrite_to_internal, sanitize_root_url
+from rime_ingest.frost.sanitization import rewrite_to_internal, sanitize_frost_endpoint, sanitize_root_url
 from rime_ingest.frost.types import FrostEntityRef, FrostUrl
 from rime_ingest.frost.versions import FrostVersions
 from rime_ingest.sta.core import Observation, SensorThingsObject
@@ -148,8 +154,7 @@ def make_frost_entity(
 def frost_observation_upload(
         sensor_name: SensorUUID,
         observation_set: tuple[Observation, CanonicalDatastreams | str],
-        root_url: str | None = None,
-        version: str | None = None,
+        frost_endpoint: str = os.getenv("FROST_ENDPOINT", FROST_ENDPOINT_DEFAULT),
         read_auth_headers: Optional[str] = None,
         write_auth_headers: Optional[str] = None,
 ) -> FrostEntityRef:
@@ -157,18 +162,19 @@ def frost_observation_upload(
 
     Resolves the Datastream entity URL from the sensor and datastream names,
     then delegates to ``make_frost_entity``, which appends ``/Observations`` and
-    silently skips duplicates. Connection config defaults to env-var values so callers
-    that set ``FROST_ENDPOINT`` do not need to pass them explicitly.
+    silently skips duplicates. Connection config defaults to ``FROST_ENDPOINT``
+    env var so callers do not need to pass an endpoint explicitly.
 
     Args:
         sensor_name: Unique name of the sensor that owns the datastream.
         observation_set: Tuple of ``(Observation, datastream_name_str)``
             produced by a transformer (``datastream`` is the ``.value`` of an
             ``ObservedProperties`` enum member, i.e. a plain string).
-        root_url: FROST server root URL. Defaults to ``FROST_ENDPOINT`` env var.
-        version: API version. Defaults to ``FROST_VERSION`` env var.
-        auth_headers: Base64-encoded credentials. Defaults to
-            ``FROST_AUTH_HEADER`` env var.
+        frost_endpoint: FROST endpoint URL (from ``FROST_ENDPOINT``).
+        read_auth_headers: Base64-encoded read credentials. Defaults to
+            credentials for ``frost_endpoint`` in ``frost_credentials.json``.
+        write_auth_headers: Base64-encoded write credentials. Defaults to
+            credentials for ``frost_endpoint`` in ``frost_credentials.json``.
 
     Returns:
         Reference to the existing or newly created Observation entity.
@@ -179,11 +185,10 @@ def frost_observation_upload(
     """
     # Deferred import: get.py imports helpers.py, which imports this module.
     from rime_ingest.frost.get import find_datastream_observations_url
-    _root, _version = get_frost_root_url()
-    root_url = root_url or _root
-    version = version or _version
-    write_auth = write_auth_headers or get_frost_auth_header("write")
-    read_auth = read_auth_headers or get_frost_auth_header("read")
+    endpoint, root_url, version = sanitize_frost_endpoint(frost_endpoint)
+
+    write_auth = write_auth_headers or get_frost_auth_header("write", endpoint)
+    read_auth = read_auth_headers or get_frost_auth_header("read", endpoint)
 
     observation, datastream = observation_set
     datastream_name = (

--- a/packages/rime-ingest/src/rime_ingest/frost/sanitization.py
+++ b/packages/rime-ingest/src/rime_ingest/frost/sanitization.py
@@ -1,5 +1,7 @@
 """Sanitization helpers for FROST request URLs."""
 #standard
+import os
+import re
 from urllib.parse import urlparse
 #internal
 from typing import Optional, Mapping, Any
@@ -11,6 +13,29 @@ from rime_ingest.sta.schema import (
     SensorThingsEntity,
     SensorThingsEntityGroups,
 )
+
+def sanitize_frost_endpoint(
+    endpoint: str,
+    version: str | int | float | FrostVersions | None = None,
+) -> tuple[str, str, FrostVersions]:
+    """Parse a FROST endpoint into credential key, root URL, and API version.
+
+    ``endpoint`` may be comma-separated (as in ``FROST_ENDPOINT``); the first
+    entry is used. A trailing ``/vX.Y`` segment, if present, is split off as
+    the API version; otherwise ``version`` or ``FROST_VERSION`` is used.
+
+    Returns:
+        ``(endpoint_key, root_url, version)`` where ``endpoint_key`` is the
+        trimmed endpoint string used for credential lookup.
+    """
+    endpoint = endpoint.split(",")[0].strip().rstrip("/")
+    fallback_version = (
+        version if version is not None else os.getenv("FROST_VERSION", FrostVersions.v1_1)
+    )
+    m = re.match(r"^(.*?)/(v[\d.]+)$", endpoint)
+    if m:
+        return endpoint, m.group(1), FrostVersions.safe_parse(m.group(2))
+    return endpoint, endpoint, FrostVersions.safe_parse(fallback_version)
 
 def sanitize_get_request(
     root_url: str,

--- a/packages/rime-ingest/src/rime_ingest/main.py
+++ b/packages/rime-ingest/src/rime_ingest/main.py
@@ -1,4 +1,5 @@
 # standard
+from copy import deepcopy
 from typing import List, Optional
 import logging
 from pathlib import Path
@@ -125,7 +126,7 @@ def push_available(
         sensor_registry[sensor_config.name] = SupportedSensors(sensor_config.model)
         netmon.expected_sensors.add(sensor_config.name)
         for endpoint in endpoints:
-            _setup_sensor_arrangements(sensor_config, endpoint)
+            _setup_sensor_arrangements(deepcopy(sensor_config), endpoint)
     # generate a list of connections
     sensor_connections = parse_application_config(APPLICATION_CONFIG_FILE)
 

--- a/packages/rime-ingest/src/rime_ingest/main.py
+++ b/packages/rime-ingest/src/rime_ingest/main.py
@@ -11,15 +11,14 @@ import os
 from rime_ingest.loggers import setup_loggers  # noqa: F401
 from rime_ingest.paths import APPLICATION_CONFIG_FILE
 from rime_ingest.config import (
-    FROST_VERSION,
-    FrostVersions,
+    FROST_ENDPOINT_DEFAULT,
     generate_sensor_config_files,
     get_frost_auth_header,
-    get_frost_root_url,
 )
 from rime_ingest.providers.registry import PROVIDER_REGISTRY
 from rime_ingest.sta.extensions import SensorConfig
 from rime_ingest.frost.orchestrators import initial_setup
+from rime_ingest.frost.sanitization import sanitize_frost_endpoint
 from rime_ingest.transport import SensorTransport
 from rime_ingest.monitor import netmon
 from rime_ingest.transformers.types import SensorUUID, SupportedSensors
@@ -69,17 +68,16 @@ def parse_application_config(config_path: Path) -> set[SensorTransport]:
 
     return connections
 
-
 def _setup_sensor_arrangements(
     sensor_config: SensorConfig,
-    root_url: str,
+    endpoint: str,
 ) -> None:
     """Provision a SensorConfig as FROST entities (idempotent).
 
     Args:
         sensor_config: Parsed sensor configuration.
-        root_url: FROST server root, e.g. ``http://host/FROST-Server``.
-        version: SensorThings API version string, e.g. ``"v1.1"``.
+        endpoint: FROST endpoint URL from ``FROST_ENDPOINT``, e.g.
+            ``http://host/FROST-Server`` or ``http://host/FROST-Server/v1.1``.
     """
     if not sensor_config.is_valid:
         netmon.add_count("sensor_config_fail", 1)
@@ -88,35 +86,34 @@ def _setup_sensor_arrangements(
         )
         return None
 
+    endpoint, root_url, version = sanitize_frost_endpoint(endpoint)
+
     initial_setup(
         sensor_config,
         root_url=root_url,
-        version=FROST_VERSION,
-        write_auth_headers=get_frost_auth_header("write"),
-        read_auth_headers=get_frost_auth_header("read"),
+        version=version,
+        write_auth_headers=get_frost_auth_header("write", endpoint),
+        read_auth_headers=get_frost_auth_header("read", endpoint),
     )
 
 def push_available(
     sensor_config_paths: List[Path] = generate_sensor_config_files(),
     exclude: Optional[List[SensorUUID]] = None,
-    frost_endpoint: Optional[str] = None,
-    start_delay: int = 30,
+    frost_endpoints: str = os.getenv("FROST_ENDPOINT", FROST_ENDPOINT_DEFAULT),
+    start_delay: int = 10,
 ) -> None:
     """Start app threads and begin collecting data, pushing to FROST server.
 
     Args:
         sensor_config_paths: List of sensor configuration file paths.
         exclude: Sensor UUIDs to skip.
-        frost_endpoint: Override FROST endpoint (``http://host/FROST-Server/vX.Y``).
-            When omitted, ``FROST_ENDPOINT`` env var or the compiled default is used.
+        frost_endpoints (str): One or more FROST endpoints to push too, defaults to 
+            FROST_ENDPOINT_DEFAULT. 
         start_delay: Seconds to wait before starting the collection loop.
     """
-    if frost_endpoint:
-        os.environ["FROST_ENDPOINT"] = frost_endpoint
-
-    root_url, version = get_frost_root_url()
+    endpoints = [e.strip() for e in frost_endpoints.split(",")]
     event_logger.info(
-        f"Sensor stream starts in {start_delay}s, target: {root_url}/v{version}."
+        f"Streaming starting in {start_delay}s, pushing to {len(endpoints)} target/s: {endpoints}."
     )
     time.sleep(start_delay)
     # INITIAL SETUP ############################################################
@@ -127,14 +124,15 @@ def push_available(
         sensor_config = SensorConfig(f)
         sensor_registry[sensor_config.name] = SupportedSensors(sensor_config.model)
         netmon.expected_sensors.add(sensor_config.name)
-        _setup_sensor_arrangements(sensor_config, root_url)
+        for endpoint in endpoints:
+            _setup_sensor_arrangements(sensor_config, endpoint)
     # generate a list of connections
     sensor_connections = parse_application_config(APPLICATION_CONFIG_FILE)
 
     netmon.set_starting_threads([_.app_name for _ in sensor_connections])
 
     for connection in sensor_connections:
-        connection.start(sensor_registry)
+        connection.start(sensor_registry, frost_endpoints=endpoints)
         # network monitor will be responsible for restarting dead threads:
         netmon.connections.add(connection)
 

--- a/packages/rime-ingest/src/rime_ingest/preflight/types.py
+++ b/packages/rime-ingest/src/rime_ingest/preflight/types.py
@@ -24,9 +24,17 @@ class AppCredentialStore(RootModel):
 
     root: Dict[str, AppCredential] = Field(..., min_length=1)
 
-class FrostCredentials(BaseModel):
-    frost_username: str = Field(..., min_length=1)
-    frost_password: str = Field(..., min_length=1)
+class FrostEndpointCredentials(BaseModel):
+    frost_write_username: str = Field(..., min_length=1)
+    frost_write_password: str = Field(..., min_length=1)
+    frost_read_username: str = Field(..., min_length=1)
+    frost_read_password: str = Field(..., min_length=1)
+
+
+class FrostCredentials(RootModel):
+    """Maps each FROST endpoint URL to its read/write credential pairs."""
+
+    root: Dict[str, FrostEndpointCredentials] = Field(..., min_length=1)
 
 class PostgresCredentials(BaseModel):
     postgres_user: str = Field(..., min_length=1)

--- a/packages/rime-ingest/src/rime_ingest/preflight/validation.py
+++ b/packages/rime-ingest/src/rime_ingest/preflight/validation.py
@@ -39,7 +39,7 @@ def validate_frost_credentials(file_path: Path) -> Tuple[bool, List[str]]:
         return (False, [f"Error reading {file_path.name}: {str(e)}"])
     
     try:
-        FrostCredentials(**data)
+        FrostCredentials.model_validate(data)
         return (True, [])
     except ValidationError as e:
         errors = [f"Validation errors in {file_path.name}:"]

--- a/packages/rime-ingest/src/rime_ingest/transport/base.py
+++ b/packages/rime-ingest/src/rime_ingest/transport/base.py
@@ -42,6 +42,7 @@ own auth in whatever method they need.
 #stdlib
 import inspect
 import logging
+import os
 import queue
 import threading
 import traceback
@@ -50,6 +51,7 @@ from typing import Any, Literal
 #internal
 
 from .buffers import BufferedObservationFlush, TransportBufferStore
+from ..config import FROST_ENDPOINT_DEFAULT
 from ..frost.post import frost_observation_upload
 from ..monitor import netmon
 from ..transformers.ingest_registry import resolve_identified_payload
@@ -72,6 +74,10 @@ main_logger = logging.getLogger("main")
 event_logger = logging.getLogger("events")
 debug_logger = logging.getLogger("debug")
 
+_DEFAULT_FROST_ENDPOINTS: tuple[str, ...] = tuple(
+    e.strip() for e in os.getenv("FROST_ENDPOINT", FROST_ENDPOINT_DEFAULT).split(",")
+)
+
 class SensorTransport(ABC):
     """Abstract base for any managed link to an upstream sensor data source."""
 
@@ -85,6 +91,7 @@ class SensorTransport(ABC):
         self.app_name = app_name
         self.max_retries = max_retries
         self._buffer_store = buffer_store or TransportBufferStore()
+        self.frost_endpoints: list[str] = []
         #TODO: sensor_registry as an attr is a codesmell
         self.sensor_registry: dict[SensorUUID, SupportedSensors] = {}
         self._thread: threading.Thread | None = None
@@ -136,13 +143,19 @@ class SensorTransport(ABC):
         """
         ...
 
-    def start(self, sensor_registry: dict[SensorUUID, SupportedSensors]) -> None:
+    def start(
+        self,
+        sensor_registry: dict[SensorUUID, SupportedSensors],
+        *,
+        frost_endpoints: list[str] | tuple[str, ...] = _DEFAULT_FROST_ENDPOINTS,
+    ) -> None:
         """Start the transport's worker thread.
 
         Skips startup if `_preflight` fails. Idempotent: re-calling while the
         thread is alive is a no-op.
         """
         self.sensor_registry = sensor_registry
+        self.frost_endpoints = list(frost_endpoints)
         if not self._preflight():
             event_logger.warning(
                 f"Preflight check failed for {self.app_name}; not starting connection."
@@ -171,7 +184,7 @@ class SensorTransport(ABC):
                 "sensor registry available."
             )
         self._stop_event.clear()
-        self.start(self.sensor_registry)
+        self.start(self.sensor_registry, frost_endpoints=self.frost_endpoints)
 
     # processing ###############################################################
     def _decode_wire(self, raw: Any) -> Any:
@@ -277,7 +290,12 @@ class SensorTransport(ABC):
         flush: BufferedObservationFlush,
         sensor_model: SupportedSensors,
     ) -> None:
-        frost_observation_upload(flush.sensor_uuid, flush.payload)
+        for endpoint in self.frost_endpoints:
+            frost_observation_upload(
+                flush.sensor_uuid,
+                flush.payload,
+                frost_endpoint=endpoint,
+            )
         self._buffer_store.commit_flush(flush.key)
         event_logger.info(
             f"Received and processed a wire message from {self.app_name} "
@@ -290,7 +308,12 @@ class SensorTransport(ABC):
         for flush in self._buffer_store.drain_pending_for_sensors(self.sensor_registry):
             sensor_uuid, sensor_model, _ = flush.key
             try:
-                frost_observation_upload(flush.sensor_uuid, flush.payload)
+                for endpoint in self.frost_endpoints:
+                    frost_observation_upload(
+                        flush.sensor_uuid,
+                        flush.payload,
+                        frost_endpoint=endpoint,
+                    )
                 self._buffer_store.commit_flush(flush.key)
                 event_logger.info(
                     f"Flushed buffered observations from {self.app_name} "


### PR DESCRIPTION
Ingest services can now point to multiple endpoints, which is much more effective than running a service per endpoint.